### PR TITLE
expose the current running exception to user code

### DIFF
--- a/src/WaterPipe/WaterPipe.php
+++ b/src/WaterPipe/WaterPipe.php
@@ -156,7 +156,7 @@ class WaterPipe
 
     /**
      * In case an exception occurs during pipe execution, it will be
-     * stored here for user code to read in middlewares and errorhandlers
+     * stored here for user code to read in middlewares and error handlers
      *
      * @var Exception
      */

--- a/src/WaterPipe/WaterPipe.php
+++ b/src/WaterPipe/WaterPipe.php
@@ -155,7 +155,7 @@ class WaterPipe
     private $_mapRegistry;
 
     /**
-     * In case an exception occures during pipe execution, it will be
+     * In case an exception occurs during pipe execution, it will be
      * stored here for user code to read in middlewares and errorhandlers
      *
      * @var Exception

--- a/src/WaterPipe/WaterPipe.php
+++ b/src/WaterPipe/WaterPipe.php
@@ -158,7 +158,7 @@ class WaterPipe
      * In case an exception occurs during pipe execution, it will be
      * stored here for user code to read in middlewares and error handlers
      *
-     * @var Exception
+     * @var \Exception
      */
     private $_runningException;    
     

--- a/src/WaterPipe/WaterPipe.php
+++ b/src/WaterPipe/WaterPipe.php
@@ -155,6 +155,14 @@ class WaterPipe
     private $_mapRegistry;
 
     /**
+     * In case an exception occures during pipe execution, it will be
+     * stored here for user code to read in middlewares and errorhandlers
+     *
+     * @var Exception
+     */
+    private $_runningException;    
+    
+    /**
      * @return WaterPipe
      */
     public static function getRunningInstance(): WaterPipe
@@ -206,6 +214,7 @@ class WaterPipe
         $this->_errorsRegistry = array();
         $this->_pipesRegistry = array();
         $this->_mapRegistry = array();
+        $this->_runningException = null;
     }
 
     /**
@@ -430,6 +439,15 @@ class WaterPipe
             $pipe[1]->_runBase($pipe[0]);
         }
     }
+    
+    /**
+     * If an exception has occured while running the pipe
+     * This method will return that exception.
+     * Otherwise, will return null.
+     */
+    function getRunningException () {
+        return $this->_runningException;
+    }
 
     /**
      * @param string $baseUri
@@ -546,6 +564,8 @@ class WaterPipe
             // NOTE: No code will be executed after this call...
             $this->_executeAction($runner);
         } catch (\Exception $e) {
+            $this->_runningException = $e;
+            
             if (isset($this->_errorsRegistry[500])) {
                 $this->_executeAction($this->_errorsRegistry[500]);
             } else {

--- a/src/WaterPipe/WaterPipe.php
+++ b/src/WaterPipe/WaterPipe.php
@@ -444,6 +444,7 @@ class WaterPipe
      * If an exception has occured while running the pipe
      * This method will return that exception.
      * Otherwise, will return null.
+     * @return \Exception
      */
     function getRunningException () {
         return $this->_runningException;


### PR DESCRIPTION
In case of exception during pipe exception, it will be stored and make available to user code using the `getRunningException` function.
It is intended to be used in middlewares (in beforeSend hook) or in the error handlers.

This change has been done in the least intrusive way possible : 
- it is completely backward compatible 
- there are no change in middlewares nor error handlers signatures