### PR TITLE
Implement errors loggers

### DIFF
--- a/src/WaterPipe/Configuration/DefaultErrorLogger.php
+++ b/src/WaterPipe/Configuration/DefaultErrorLogger.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * WaterPipe - URL routing framework for PHP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @category  Library
+ * @package   WaterPipe
+ * @author    Axel Nana <ax.lnana@outlook.com>
+ * @copyright 2018 Aliens Group, Inc.
+ * @license   MIT <https://github.com/ElementaryFramework/WaterPipe/blob/master/LICENSE>
+ * @version   1.3.0
+ * @link      http://waterpipe.na2axl.tk
+ */
+
+namespace ElementaryFramework\WaterPipe\Configuration;
+
+/**
+ * Error logger based on the `error_log` PHP function.
+ */
+class DefaultErrorLogger implements IErrorLogger
+{
+    /**
+     * The message type.
+     * The field only take as values the ones accepted by the
+     * second parameter of the `error_log` PHP function.
+     *
+     * @var integer
+     */
+    private $_messageType;
+
+    /**
+     * The message destination.
+     * The field only take as values the ones accepted by the
+     * third parameter of the `error_log` PHP function.
+     *
+     * @var string
+     */
+    private $_destination;
+
+    /**
+     * The message extra headers.
+     * The field is only used when message type equals 1, and
+     * only take as values the ones accepted by the
+     * fourth parameter of the `error_log` PHP function.
+     *
+     * @var string
+     */
+    private $_extraHeaders;
+
+    /**
+     * Creates a new instance of the default error logger.
+     *
+     * @param integer $messageType  The message type, serving as the second parameter of the `error_log` PHP function
+     * @param string  $destination  The message destination, serving as the third parameter of the `error_log` PHP function
+     * @param string  $extraHeaders The message extra headers, serving as the fourth parameter of the `error_log` PHP function
+     */
+    public function __construct($messageType = null, $destination = null, $extraHeaders = null)
+    {
+        $this->_messageType = $messageType;
+        $this->_destination = $destination;
+        $this->_extraHeaders = $extraHeaders;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function log(string $message)
+    {
+        error_log($message, $this->_messageType, $this->_destination, $this->_extraHeaders);
+    }
+}

--- a/src/WaterPipe/Configuration/IErrorLogger.php
+++ b/src/WaterPipe/Configuration/IErrorLogger.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * WaterPipe - URL routing framework for PHP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @category  Library
+ * @package   WaterPipe
+ * @author    Axel Nana <ax.lnana@outlook.com>
+ * @copyright 2018 Aliens Group, Inc.
+ * @license   MIT <https://github.com/ElementaryFramework/WaterPipe/blob/master/LICENSE>
+ * @version   1.3.0
+ * @link      http://waterpipe.na2axl.tk
+ */
+
+namespace ElementaryFramework\WaterPipe\Configuration;
+
+/**
+ * Interface used to recognize an error logging configuration
+ * entry.
+ */
+interface IErrorLogger
+{
+    /**
+     * Logs the given message to the output wrapped by this IErrorLoggingConfiguration
+     * implementation
+     *
+     * @param string $message The message to log.
+     * 
+     * @return void
+     */
+    public function log(string $message);
+}

--- a/src/WaterPipe/Configuration/StdErrorLogger.php
+++ b/src/WaterPipe/Configuration/StdErrorLogger.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * WaterPipe - URL routing framework for PHP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @category  Library
+ * @package   WaterPipe
+ * @author    Axel Nana <ax.lnana@outlook.com>
+ * @copyright 2018 Aliens Group, Inc.
+ * @license   MIT <https://github.com/ElementaryFramework/WaterPipe/blob/master/LICENSE>
+ * @version   1.3.0
+ * @link      http://waterpipe.na2axl.tk
+ */
+
+namespace ElementaryFramework\WaterPipe\Configuration;
+
+/**
+ * Error logger which redirect message to the STDERR output stream.
+ */
+class StdErrorLogger implements IErrorLogger
+{
+    /**
+     * @inheritDoc
+     */
+    public function log(string $message)
+    {
+        $stream = fopen("php://stderr", 'w');
+        fwrite($stream, $message, strlen($message));
+        fclose($stream);
+    }
+}

--- a/src/WaterPipe/WaterPipe.php
+++ b/src/WaterPipe/WaterPipe.php
@@ -570,11 +570,10 @@ class WaterPipe
                 $this->_executeAction($this->_errorsRegistry[ResponseStatus::InternalServerErrorCode]);
             } else {
                 $config = WaterPipeConfig::get();
-                if ($config->useStderr()) {
-                    $stream = fopen("php://stderr", 'w');
+                $logger = $config->errorLogger();
+                if ($logger !== null) {
                     $string = $e->__toString();
-                    fwrite($stream, $string, strlen($string));
-                    fclose($stream);
+                    $logger->log($string);
                 } else throw $e;
             }
         }

--- a/src/WaterPipe/WaterPipeConfig.php
+++ b/src/WaterPipe/WaterPipeConfig.php
@@ -32,6 +32,10 @@
 
 namespace ElementaryFramework\WaterPipe;
 
+use ElementaryFramework\WaterPipe\Configuration\DefaultErrorLogger;
+use ElementaryFramework\WaterPipe\Configuration\IErrorLogger;
+use ElementaryFramework\WaterPipe\Configuration\StdErrorLogger;
+
 class WaterPipeConfig
 {
     /**
@@ -71,18 +75,19 @@ class WaterPipeConfig
     private $_defaultCharset = "utf-8";
 
     /**
-     * Defines if WaterPipe uses the stderr output channel
-     * to print errors and uncaught exceptions.
+     * Defines the error logger to use in WaterPipe.
      *
-     * @var bool
+     * @var IErrorLogger
      */
-    private $_useStderr = true;
+    private $_errorLogger = null;
 
     /**
      * WaterPipeConfig constructor.
      */
     private function __construct()
-    { }
+    {
+        $this->_errorLogger = new DefaultErrorLogger();
+    }
 
     /**
      * Checks if query strings are enabled.
@@ -97,14 +102,20 @@ class WaterPipeConfig
     /**
      * Set the enabled state of query strings.
      *
-     * @param bool $enable
+     * @param bool $enable true to enable query strings, false otherwise.
+     * 
+     * @return self
      */
-    public function setQueryStringEnabled(bool $enable): void
+    public function setQueryStringEnabled(bool $enable): WaterPipeConfig
     {
         $this->_queryStringEnabled = $enable;
+
+        return $this;
     }
 
     /**
+     * Returns the defined default charset.
+     * 
      * @return string
      */
     public function getDefaultCharset(): string
@@ -113,33 +124,71 @@ class WaterPipeConfig
     }
 
     /**
+     * Sets the default charset to use when sending responses.
+     * 
      * @param string $defaultCharset
+     * 
+     * @return self
      */
-    public function setDefaultCharset(string $defaultCharset): void
+    public function setDefaultCharset(string $defaultCharset): WaterPipeConfig
     {
         $this->_defaultCharset = $defaultCharset;
+
+        return $this;
     }
 
     /**
      * Checks if WaterPipe print errors and uncaught exceptions in the stderr.
+     * This method is deprecated and it is not recommended to use it in new projects.
      *
+     * @deprecated 1.3.0
+     * 
      * @return  bool
      */
-    public function useStderr()
+    public function useStderr(): bool
     {
-        return $this->_useStderr;
+        return $this->_errorLogger instanceof StdErrorLogger;
     }
 
     /**
      * Set if WaterPipe have to print errors and uncaught exceptions in the stderr.
+     * This method is deprecated and it is not recommended to use it in new projects.
      *
+     * @deprecated 1.3.0
+     * 
      * @param  bool $useStderr True to enable, false to disable.
      *
-     * @return  self
+     * @return self
      */
-    public function setUseStderr(bool $useStderr)
+    public function setUseStderr(bool $useStderr): WaterPipeConfig
     {
-        $this->_useStderr = $useStderr;
+        $this->_errorLogger = $useStderr
+            ? new StdErrorLogger()
+            : new DefaultErrorLogger();
+
+        return $this;
+    }
+
+    /**
+     * Gets the error logger currently used by WaterPipe.
+     *
+     * @return IErrorLogger
+     */
+    public function errorLogger(): IErrorLogger
+    {
+        return $this->_errorLogger;
+    }
+
+    /**
+     * Defines the error logger to use in WaterPipe.
+     *
+     * @param IErrorLogger $errorLogger The error logger.
+     * 
+     * @return self
+     */
+    public function setErrorLogger(IErrorLogger $errorLogger): WaterPipeConfig
+    {
+        $this->_errorLogger = $errorLogger;
 
         return $this;
     }


### PR DESCRIPTION
#6 shows that WaterPipe lacks a strong system for errors handling. This pull request fixes that.

A different approach is used than the one discussed in #6 :

- An interface `IErrorLogger` is created to allow users to implement their own error logging system.
- Some error loggers are implemented by default:
  - `StdErrorLogger` which log errors to the STDERR stream
  - `DefaultErrorLogger` which calls the default `error_log` PHP function when logging errors
- A new entry `errorLogger` has been added to the `WaterPipeConfig`, to define the `IErrorLogger` implementation to use.
- The `DefaultErrorLogger` implementation is used by default.

Fixes #6 